### PR TITLE
add end_cursor test

### DIFF
--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -314,8 +314,8 @@ class Crawler
     }
 
     /**
-     * Set the Guzzle HTTP client with EndCursor
-     * 
+     * Set the Guzzle HTTP client with EndCursor.
+     *
      * @return void
      */
     public function setClientOnEndCursor(): void

--- a/test/CrawlerTest.php
+++ b/test/CrawlerTest.php
@@ -117,4 +117,12 @@ class CrawlerTest extends TestCase
         $this->assertEquals('taipei', ($result['tags'][0])->getName());
         $this->assertGreaterThan(8739744, ($result['tags'][0])->getCount());
     }
+
+    public function testSetClientOnEndCursor()
+    {
+        $media = $this->crawler->getMediaByTag('php');
+        $this->assertGreaterThan(0, count($media));
+        $this->crawler->setClientOnEndCursor();
+        $this->assertGreaterThan(0, count($media));
+    }
 }


### PR DESCRIPTION
# Changed log

- To get the next page for the Instagram media, I add the ```end_cursor``` test to initial the Client with the ```max_id``` if the ```max_id``` is existed.

I'm not sure this is the proper approach to implement this feature.
Please review this.

Thanks.