### PR TITLE
remove void because the PHP 7.0 doesn't support

### DIFF
--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -318,7 +318,7 @@ class Crawler
      *
      * @return void
      */
-    public function setClientOnEndCursor(): void
+    public function setClientOnEndCursor()
     {
         $this->client = new Client([
             'base_uri' => self::BASE_URI,


### PR DESCRIPTION
This is my fault because of the previous PR.
I remove the ```void``` return type hint because the PHP 7.0 doesn't support that.